### PR TITLE
Updated implementation for better type info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ var stream = fs.createReadStream('package.json')
 var output = fs.createWriteStream('package.json.gz')
 
 stream
-.pipe(zlib.createGzip())
-.pipe(Counter)
-.once('finish', function () {
-  console.log('final gzipped length is ' + this.length)
-})
-.pipe(output)
+  .pipe(zlib.createGzip())
+  .pipe(new Counter())
+  .once('finish', function () {
+    console.log('final gzipped length is ' + this.length)
+  })
+  .pipe(output)
 ```
 
 ## API
 
 ### new Counter(`options`)
 
-`new` is optional. `options` is optional and is passed into the `Stream.Transform` constructor.
+`options` is optional and is passed into the `Stream.Transform` constructor.
 
 ### counter.length
 

--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
-var util = require('util')
-var Transform = require('stream').Transform
+const { Transform } = require('node:stream')
 
-util.inherits(Counter, Transform)
+class Counter extends Transform {
+  /**
+   * @param {import('node:stream').TransformOptions=} options
+   */
+  constructor(options) {
+    super(options)
+    this.length = 0
+  }
+
+  _transform(chunk, encoding, callback) {
+    this.length += chunk.length
+    this.push(chunk)
+    callback()
+  }
+}
 
 module.exports = Counter
-
-function Counter(options) {
-  if (!(this instanceof Counter))
-    return new Counter(options)
-
-  Transform.call(this, options)
-  this.length = 0
-}
-
-Counter.prototype._transform = function (chunk, encoding, callback) {
-  this.length += chunk.length
-  this.push(chunk)
-  callback()
-}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "passthrough-counter",
   "description": "Get the total buffer length of a stream.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "license": "MIT",
   "repository": "stream-utils/passthrough-counter",

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ var length = fs.statSync(pack).size
 describe('Passthrough Counter', function () {
   it('should work', function (done) {
     var stream = fs.createReadStream(pack)
-    var counter = Counter()
+    var counter = new Counter()
     stream.pipe(counter)
     .once('finish', function () {
       assert.equal(this.length, length)


### PR DESCRIPTION
The current implementation doesn't allow for TypeScript to figure out that `Counter` extends `Transform`.
Unfortunately this can't be resolved by simply adding a declaration file since `Counter` can be called with or without `new`.
The simplest way I could come up with while changing as little as possible was to refactor the code to use the `class` syntax.
This unfortunately is a breaking change which results in any code that didn't use `new` breaking.
As such I have incremented the major version to reflect this.